### PR TITLE
feat: Add slang-style function names for asynchronous operations `keepAtIt` and `getItDone`

### DIFF
--- a/lib/src/functions.dart
+++ b/lib/src/functions.dart
@@ -39,5 +39,15 @@ Future<T> brb<T>(
   return Future.delayed(duration, computation);
 }
 
+/// Get it done, first one to finish.
+Future<T> getItDone<T>(Iterable<Future<T>> futures) {
+  return Future.any(futures);
+}
+
+/// Keep going until you hit the end.
+Future<void> keepAtIt(Future<bool> Function() condition) {
+  return Future.doWhile(condition);
+}
+
 /// Type of T.
 Type typah<T>(T wat) => T;


### PR DESCRIPTION
## Status

**READY**

## Deets

Added two new utility functions with slang-style naming for common asynchronous operations:

- `getItDone`: Wrapper for `Future.any`, returns the first future that completes.
- `keepAtIt`: Wrapper for `Future.doWhile`, continues looping while the condition returns `true`.

These functions bring a more casual and expressive naming style to async Dart code, making it more readable and fun to work with.

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
